### PR TITLE
Update bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -59,7 +59,7 @@ apt-get update
 
 
 echo "--- Install base packages… ---"
-apt-get -y install curl net-tools gcc git gnupg-agent make python openssl redis-server sudo vim zip > /dev/null
+apt-get -y install curl net-tools ifupdown gcc git gnupg-agent make python openssl redis-server sudo vim zip > /dev/null
 
 
 echo "--- Installing and configuring Postfix… ---"


### PR DESCRIPTION
ifupdown package is necessary to add private_network to allow two or more vagrant VMs to communicate on their own network
