### PR TITLE
Upgrade to Ubuntu 20.04 ++

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   # config.vm.box = "ubuntu/artful64"
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "ubuntu/jammy64"
   config.vm.provision :shell, path: "bootstrap.sh", args: MISP_ENV.to_s
 
   # Disable automatic box update checking. If you disable this, then
@@ -45,7 +45,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   disabled = true
-  vm_name = "MISP - Ubuntu 18.04"
+  vm_name = "MISP - Ubuntu 20.04"
   if MISP_ENV.to_s == "dev"
     disabled = false
     vm_name.concat(" - DEV")


### PR DESCRIPTION
Updated vagrantfile with latest ubuntu official image
Updated apt package names
Updated php version
Taken into account usage of python2 or python3
Fixed GPG export command
Moved misp-modules install to pip
Moved away from deprecated cake usage

This should fix issue #13 , #12 , #9 , #7.
Tested that "vagrant up" does not throw any errors, and I am able to login to MISP on port 5000 after.